### PR TITLE
Use HTTPS protocol instead of deprecated `git://` protocol for cloning

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>كود المصدر</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip"><span dir="ltr">3.18 Rufus</span></a> <span dir="rtl">(4.5 ميغا بايت)</span></li>
-			<li>كطريقة بديلة، يمكنك نسخ مخزن <a target="_blank" href="http://git-scm.com">git</a> باستخدام:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>كطريقة بديلة، يمكنك نسخ مخزن <a target="_blank" href="http://git-scm.com">git</a> باستخدام:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>للمزيد من المعلومات راجع <a target="_blank" href="https://github.com/pbatard/rufus">مشروع github</a>.</li></ul>
 			إذا كنت من المطورين، فنحن نشجعك بشدة على العبث بـ Rufus وإرسال التنقيحات والتحسينات.</p>
 		<a name="donate"></a>

--- a/ar_IQ/index.html
+++ b/ar_IQ/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>کۆدی سەرچاوە</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip"><span dir="ltr">3.18 Rufus</span></a> <span dir="rtl">(4.5 مێگا بایت)</span></li>
-			<li>لە جیاتی ئەوە، دەتوانی کۆپی <a target="_blank" href="http://git-scm.com">وەرگرتن</a>بە بەکارهێنانی کۆگا:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>لە جیاتی ئەوە، دەتوانی کۆپی <a target="_blank" href="http://git-scm.com">وەرگرتن</a>بە بەکارهێنانی کۆگا:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>بۆ زانیاری زیاتر، <a target="_blank" href="https://github.com/pbatard/rufus">پرۆژە </a>ببینە.</li></ul>
 			ئەگەر تۆ گەشەپێدەر بیت، زۆر دلخۆش دەبین بە تاقیکردنەوە و سەیرکردنی لەهەر هەلەیەک لە Rufus وە پاچ پێشکەش بکەن.</p>
 		<a name="donate"></a>

--- a/az/index.html
+++ b/az/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Qaynaq Kodu</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Alternativ olaraq, <a target="_blank" href="http://git-scm.com">get</a> hissəsini istifadə edərək klonlaşdıra bilərsiniz:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Alternativ olaraq, <a target="_blank" href="http://git-scm.com">get</a> hissəsini istifadə edərək klonlaşdıra bilərsiniz:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Daha çox məlumat üçün <a target="_blank" href="https://github.com/pbatard/rufus">github proyektinə</a> baxın.</li></ul>
 			İnkişafa, Rufus'u düzəlişlərə və yamaq təqdim etməyə təşviq edirik.</p>
 		<a name="donate"></a>

--- a/bg/index.html
+++ b/bg/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Изходен Код</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 МБ)</span></li>
-			<li>Алтернативно, може да клонирате <a target="_blank" href="http://git-scm.com">git</a> хранилището с помощта на:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Алтернативно, може да клонирате <a target="_blank" href="http://git-scm.com">git</a> хранилището с помощта на:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>За повече информация, вижте <a target="_blank" href="https://github.com/pbatard/rufus">проекта github</a>.</li></ul>
 			Ако сте разработчик, сте насърчавани да кърпите Rufus и представяте кръпки.</p>
 		<a name="donate"></a>

--- a/bn/index.html
+++ b/bn/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>উৎস কোড</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 মেগাবাইট)</span></li>
-			<li>অন্যথ্যায়, আপনি চাইলে <a target="_blank" href="http://git-scm.com">গিট</a> রিপোজটোরি ব্যবহার করে এটাকে ক্লোন করতে পারেন:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>অন্যথ্যায়, আপনি চাইলে <a target="_blank" href="http://git-scm.com">গিট</a> রিপোজটোরি ব্যবহার করে এটাকে ক্লোন করতে পারেন:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>বিস্তারিত তথ্যের জন্য <a target="_blank" href="https://github.com/pbatard/rufus">গিটহাব প্রজেক্ট</a> দেখুন।</li></ul>
 			আপনি যদি ডেভেলপার হোন, আপনাকে অধিক উৎসাহ দেয়া হচ্ছে Rufus এর সাথে সংশোধনে অংশ নেয়া ও প্যাচ জমা দেয়ায়।</p>
 		<a name="donate"></a>

--- a/bs/index.html
+++ b/bs/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Izvor koda</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB (MegaByte))</span></li>
-			<li>Altenativno, možete klonirati <a target="_blank" href="http://git-scm.com">Git</a>  repozitorijum  pomoću:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Altenativno, možete klonirati <a target="_blank" href="http://git-scm.com">Git</a>  repozitorijum  pomoću:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Za još više informacija, pogledajte naš <a target="_blank" href="https://github.com/pbatard/rufus">Github projekat</a>.</li></ul>
 			Ako ste programer, veoma ste ohrabreni da pravite zakrpe za Rufus.</p>
 		<a name="donate"></a>

--- a/ca/index.html
+++ b/ca/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Codi font</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>O bé, podeu clonar el repositori <a target="_blank" href="http://git-scm.com">Git</a>:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>O bé, podeu clonar el repositori <a target="_blank" href="http://git-scm.com">Git</a>:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Per a més informació, visiteu el <a target="_blank" href="https://github.com/pbatard/rufus">projecte a GitHub</a>.</li></ul>
 			Si sabeu programar, us animem al fet que trastegeu amb el Rufus y envieu pedaços.</p>
 		<a name="donate"></a>

--- a/cs/index.html
+++ b/cs/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Zdrojový kód</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>‭V alternativním případě můžete následující řádkou naklonovat <a target="_blank" href="http://git-scm.com">git</a> repozitář:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>‭V alternativním případě můžete následující řádkou naklonovat <a target="_blank" href="http://git-scm.com">git</a> repozitář:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Pro více informací navštivte <a target="_blank" href="https://github.com/pbatard/rufus">GitHub projekt</a>.</li></ul>
 			Jste-li zdatným programátorem, neváhejte Rufus otestovat přes celou délku a navrhnout jeho vylepšení.</p>
 		<a name="donate"></a>

--- a/cy/index.html
+++ b/cy/index.html
@@ -422,7 +422,7 @@ CDBurnerXP</a>.</p>
 
 		<h2>Cod Ffynhonnell</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Fel arall, gallwch glonio'r ystorfa <a target="_blank" href="http://git-scm.com">git</a> gan ddefnyddio:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Fel arall, gallwch glonio'r ystorfa <a target="_blank" href="http://git-scm.com">git</a> gan ddefnyddio:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Am ragor o wybodaeth, gweler y prosiect <a target="_blank" href="https://github.com/pbatard/rufus">github</a>.</li></ul>
 			Os ydych chi'n ddatblygwr, fe'ch anogir yn fawr i dincio gyda Rufus a chyflwyno darnau.</p>
 		<a name="donate"></a>

--- a/da/index.html
+++ b/da/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Kildekode</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Alternativt kan du klone <a target="_blank" href="http://git-scm.com">git</a>-arkivet med:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Alternativt kan du klone <a target="_blank" href="http://git-scm.com">git</a>-arkivet med:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Se <a target="_blank" href="https://github.com/pbatard/rufus">github-projektet</a> for mere information.</li></ul>
 			Hvis du er en programudvikler, er du meget velkommen til at pille ved Rufus og indsende programrettelser.</p>
 		<a name="donate"></a>

--- a/de/index.html
+++ b/de/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Quellcode</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Alternativ können Sie das <a target="_blank" href="http://git-scm.com">git-Repository</a> klonen:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Alternativ können Sie das <a target="_blank" href="http://git-scm.com">git-Repository</a> klonen:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Für weitere Informationen besuchen Sie das <a target="_blank" href="https://github.com/pbatard/rufus">GitHub-Projekt</a>.</li></ul>
 			Wenn Sie selbst ein Entwickler sind, sind Sie herzlich dazu eingeladen, an Rufus herumzubasteln und Patches einzureichen.</p>
 		<a name="donate"></a>

--- a/el/index.html
+++ b/el/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Πηγαίος κώδικας</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Εναλλακτικά, μπορείτε να κλωνοποιήσετε το <a target="_blank" href="http://git-scm.com">git</a> αποθετήριο χρησιμοποιώντας:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Εναλλακτικά, μπορείτε να κλωνοποιήσετε το <a target="_blank" href="http://git-scm.com">git</a> αποθετήριο χρησιμοποιώντας:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Για περισσότερες πληροφορίες, δείτε τη <a target="_blank" href="https://github.com/pbatard/rufus">σελίδα στο github</a>.</li></ul>
 			Εάν είστε προγραμματιστής, είστε ευπρόσδεκτος/η να δοκιμάσετε το Rufus και να υποβάλετε patches.</p>
 		<a name="donate"></a>

--- a/en/index.html
+++ b/en/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Source Code</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Alternatively, you can clone the <a target="_blank" href="http://git-scm.com">git</a> repository using:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Alternatively, you can clone the <a target="_blank" href="http://git-scm.com">git</a> repository using:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>For more information, see the <a target="_blank" href="https://github.com/pbatard/rufus">github project</a>.</li></ul>
 			If you are a developer, you are very much encouraged to tinker with Rufus and submit patches.</p>
 		<a name="donate"></a>

--- a/es/index.html
+++ b/es/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Código fuente</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>También puede clonar el repositorio de <a target="_blank" href="http://git-scm.com">Git</a> usando:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>También puede clonar el repositorio de <a target="_blank" href="http://git-scm.com">Git</a> usando:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Para obtener más información, échele un vistazo al <a target="_blank" href="https://github.com/pbatard/rufus">proyecto en GitHub</a>.</li></ul>
 			Si sabe programar, le animamos a trastear con Rufus y enviar parches.</p>
 		<a name="donate"></a>

--- a/et/index.html
+++ b/et/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Lähtekood</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Alternatiivina võite kloonida <a target="_blank" href="http://git-scm.com">git</a> andmeladu, kasutades:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Alternatiivina võite kloonida <a target="_blank" href="http://git-scm.com">git</a> andmeladu, kasutades:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Lisateavet leiate <a target="_blank" href="https://github.com/pbatard/rufus">github projektist</a>.</li></ul>
 			Kui oled arendaja, oled teretulnud Rufuse kallal nokitsema ning parandusi ja täiendusi esitama.</p>
 		<a name="donate"></a>

--- a/fa/index.html
+++ b/fa/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>کد منبع</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip"><span dir="ltr">3.18 Rufus</span></a> <span dir="rtl">(4.5 مگابایت)</span></li>
-			<li>متناوباً، شما می‌توانید انبار <a target="_blank" href="http://git-scm.com">git</a> را با استفاده از دستور زیر بازسازی کنید:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>متناوباً، شما می‌توانید انبار <a target="_blank" href="http://git-scm.com">git</a> را با استفاده از دستور زیر بازسازی کنید:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>برای اطلاعات بیشتر، <a target="_blank" href="https://github.com/pbatard/rufus">پروژه github</a> را مشاهده کنید.</li></ul>
 			اگر یک توسعه دهنده هستید، شما را بسیار به سرهم‌بندی Rufus و ارائه اصلاحیه‌ها تشویق می‌کنیم.</p>
 		<a name="donate"></a>

--- a/fi/index.html
+++ b/fi/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Lähdekoodi</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Voit vaihtoehtoisesti kloonata <a target="_blank" href="http://git-scm.com">git</a>-arkiston seuraavasti:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Voit vaihtoehtoisesti kloonata <a target="_blank" href="http://git-scm.com">git</a>-arkiston seuraavasti:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Saadakseksi lisätietoa, katso <a target="_blank" href="https://github.com/pbatard/rufus">github-projekti</a>.</li></ul>
 			Jos olet kehittäjä, rohkaisemme sinua näpertelemään Rufuksen kanssa ja esittämään päivityksiä.</p>
 		<a name="donate"></a>

--- a/files/grub-2.02~beta2/readme.txt
+++ b/files/grub-2.02~beta2/readme.txt
@@ -1,3 +1,3 @@
-core.img was compiled from git://git.savannah.gnu.org/grub.git, commit
+core.img was compiled from https://git.savannah.gnu.org/grub.git, commit
 72ec399ad8d6348b6c74ea63d80c79784c8b84ae, on a Debian 7.7.0 x64 system using the
 guide from: http://pete.akeo.ie/2014/05/compiling-and-installing-grub2-for.html.

--- a/files/grub-2.03/readme.txt
+++ b/files/grub-2.03/readme.txt
@@ -1,5 +1,5 @@
 core.img was created from the latest git source on 2018.11.22 from
-  git://git.savannah.gnu.org/grub.git
+  https://git.savannah.gnu.org/grub.git
 on a Debian 9.6 x64 system using the commands:
   ./autogen.sh
   # --enable-boot-time for Manjaro Linux

--- a/fr/index.html
+++ b/fr/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Code Source</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 Mo)</span></li>
-			<li>Sinon, vous pouvez cloner le répertoire <a target="_blank" href="http://git-scm.com">git</a> en utilisant :			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Sinon, vous pouvez cloner le répertoire <a target="_blank" href="http://git-scm.com">git</a> en utilisant :			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Pour plus d'information, veuillez consulter le <a target="_blank" href="https://github.com/pbatard/rufus">projet github</a>.</li></ul>
 			Si vous êtes développeur, vous êtes cordialement invité à modifier Rufus et soumettre des patchs.</p>
 		<a name="donate"></a>

--- a/ga/index.html
+++ b/ga/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Cód foinse</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Nó, is féidir leat an stór <a target="_blank" href="http://git-scm.com">git</a> a chlónáil ag baint úsáide as:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Nó, is féidir leat an stór <a target="_blank" href="http://git-scm.com">git</a> a chlónáil ag baint úsáide as:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Le haghaidh tuilleadh eolais, féach an tionscadal <a target="_blank" href="https://github.com/pbatard/rufus">github</a>.</li></ul>
 			Más forbróir thú, moltar go láidir duit Rufus a mhodhnú agus feabhsuithe a chur isteach.</p>
 		<a name="donate"></a>

--- a/gl/index.html
+++ b/gl/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Código Fonte</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Tamén podes clonar o repositorio <a target="_blank" href="http://git-scm.com">git</a> usando:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Tamén podes clonar o repositorio <a target="_blank" href="http://git-scm.com">git</a> usando:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Para máis información, visite o <a target="_blank" href="https://github.com/pbatard/rufus">proxecto de github</a>.</li></ul>
 			Se es un programador, animámosche a fedellar con Rufus e enviar parches.</p>
 		<a name="donate"></a>

--- a/he/index.html
+++ b/he/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>קוד מקור</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip"><span dir="ltr">3.18 Rufus</span></a> <span dir="rtl">(4.5 מ״ב)</span></li>
-			<li>לחלופין, ניתן לשכפל את מאגר ה־<a target="_blank" href="http://git-scm.com">git</a> באמצעות:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>לחלופין, ניתן לשכפל את מאגר ה־<a target="_blank" href="http://git-scm.com">git</a> באמצעות:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>למידע נוסף, ניתן לראות את הפרוייקט ב־<a target="_blank" href="https://github.com/pbatard/rufus">github</a>.</li></ul>
 			אם אתה מפתח תוכנה, אני מעודד אותך להתעסק עם Rufus ולהגיש טלאים.</p>
 		<a name="donate"></a>

--- a/hi/index.html
+++ b/hi/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>सोर्स कोड</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 एमबी)</span></li>
-			<li>वैकल्पिक रूप से, आप <a target="_blank" href="http://git-scm.com">git</a> भंडार का उपयोग करके क्लोन कर सकते हैं:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>वैकल्पिक रूप से, आप <a target="_blank" href="http://git-scm.com">git</a> भंडार का उपयोग करके क्लोन कर सकते हैं:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>अधिक जानकारी के लिए, <a target="_blank" href="https://github.com/pbatard/rufus">github प्रोजेक्ट</a> देखें.</li></ul>
 			यदि आप एक डेवलपर हैं, तो आपको रूफस के साथ टिंकर करने और पैच जमा करने के लिए बहुत प्रोत्साहित किया जाता है.</p>
 		<a name="donate"></a>

--- a/hr/index.html
+++ b/hr/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Izvorni kod</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Ili možete klonirati <a target="_blank" href="http://git-scm.com">git</a> repozitorij pomoću:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Ili možete klonirati <a target="_blank" href="http://git-scm.com">git</a> repozitorij pomoću:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Za dodatne informacije, pogledajte <a target="_blank" href="https://github.com/pbatard/rufus">github projekt</a>.</li></ul>
 			Ukoliko ste programer, dobrodošli ste petljati s Rufusom i ponuditi zakrpe.</p>
 		<a name="donate"></a>

--- a/hu/index.html
+++ b/hu/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Forráskód</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Egyébként klónozhatja a <a target="_blank" href="http://git-scm.com">git</a> tárólót a következő használatával:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Egyébként klónozhatja a <a target="_blank" href="http://git-scm.com">git</a> tárólót a következő használatával:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>További információkért lásd a <a target="_blank" href="https://github.com/pbatard/rufus">GitHub projektet</a>.</li></ul>
 			Ha Ön fejlesztő, akkor feltétlenül arra bátorítjuk, hogy bütyköljön a Rufussal, és küldjön foltokat.</p>
 		<a name="donate"></a>

--- a/hy/index.html
+++ b/hy/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Սկզբնաղբյուրի Կոդ</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 ՄԲ)</span></li>
-			<li>Այլապես, Դուք կարող եք կրկնօրինակել <a target="_blank" href="http://git-scm.com"> git </a> շտեմարանը օգտագործելով՝			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Այլապես, Դուք կարող եք կրկնօրինակել <a target="_blank" href="http://git-scm.com"> git </a> շտեմարանը օգտագործելով՝			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Լրացուցիչ տեղեկությունների համար այցելե՛ք՝ <a target="_blank" href="https://github.com/pbatard/rufus"> github նախաձեռնությունը </a>:</li></ul>
 			Եթե Դուք ծրագրավորող եք, ապա Rufus-ի սխալների գտնելը, ուղղելը և լուծումի հրապարակելը մեծապես խրախուսվում է:</p>
 		<a name="donate"></a>

--- a/id/index.html
+++ b/id/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Kode Sumber</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Alternatif lain, Anda dapat melakukan clone repositori <a target="_blank" href="http://git-scm.com">git</a> ini menggunakan:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Alternatif lain, Anda dapat melakukan clone repositori <a target="_blank" href="http://git-scm.com">git</a> ini menggunakan:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Untuk informasi lebih lanjut, lihat <a target="_blank" href="https://github.com/pbatard/rufus">proyek github</a>.</li></ul>
 			Jika Anda seorang pengembang, Anda sangat disarankan untuk memperbaiki Rufus dan mengirimkan patch.</p>
 		<a name="donate"></a>

--- a/index.php
+++ b/index.php
@@ -454,7 +454,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 		<h2><?= _("Source Code");?></h2>
 			<p><ul><li><?= /* Abbreviation for MegaByte */ "<a target=\"_blank\" href=\"https://github.com/pbatard/rufus/archive/v" . $latest_version . ".zip\">" . $app_name . "</a> <span dir=\"" . $dir . "\">(" . $src_size . " " . _("MB") . ")";?></span></li>
 			<li><? printf(_("Alternatively, you can clone the <a target=\"_blank\" %s>git</a> repository using:"), "href=\"http://git-scm.com\"");?>
-			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li><? printf(_("For more information, see the <a target=\"_blank\" %s>github project</a>."), "href=\"https://github.com/pbatard/rufus\"");?></li></ul>
 			<?= _("If you are a developer, you are very much encouraged to tinker with Rufus and submit patches.");?></p>
 		<a name="donate"></a>

--- a/it/index.html
+++ b/it/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Codice sorgente</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>In alternativa, puoi clonare il repository <a target="_blank" href="http://git-scm.com">git</a> usando:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>In alternativa, puoi clonare il repository <a target="_blank" href="http://git-scm.com">git</a> usando:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Per maggiori informazioni, vai al <a target="_blank" href="https://github.com/pbatard/rufus">progetto github</a>.</li></ul>
 			Se sei uno sviluppatore, sei vivamente incoraggiato a migliorare Rufus e inviarci le patch.</p>
 		<a name="donate"></a>

--- a/ja/index.html
+++ b/ja/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>ソースコード</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>次のコマンドで<a target="_blank" href="http://git-scm.com">git</a> レポジトリをクローン (ダウンロード) することもできます。			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>次のコマンドで<a target="_blank" href="http://git-scm.com">git</a> レポジトリをクローン (ダウンロード) することもできます。			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>詳細については、<a target="_blank" href="https://github.com/pbatard/rufus">GitHubのプロジェクトページ</a>をご参照ください。</li></ul>
 			あなたが開発者であれば、ぜひRufusをさらに改善してアップデートのためのパッチを送ってください。</p>
 		<a name="donate"></a>

--- a/ko/index.html
+++ b/ko/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>소스 코드</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>또한 다음 명령을 사용하여 <a target="_blank" href="http://git-scm.com">git</a> 저장소를 복제할 수 있습니다:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>또한 다음 명령을 사용하여 <a target="_blank" href="http://git-scm.com">git</a> 저장소를 복제할 수 있습니다:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>더 많은 정보를 보려면 <a target="_blank" href="https://github.com/pbatard/rufus">GitHub 프로젝트</a>를 참고하십시오.</li></ul>
 			만약 개발을 할 수 있다면 Rufus를 직접 수정해 보고 패치 파일을 보내 주시는 것을 적극적으로 권장합니다.</p>
 		<a name="donate"></a>

--- a/lt/index.html
+++ b/lt/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Išeities kodas</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Arba jūs galite klonuoti <a target="_blank" href="http://git-scm.com">git</a> saugyklą, naudodami:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Arba jūs galite klonuoti <a target="_blank" href="http://git-scm.com">git</a> saugyklą, naudodami:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Daugiau informacijos rasite <a target="_blank" href="https://github.com/pbatard/rufus">GitHub projekte</a>.</li></ul>
 			Jei programuojate, raginame pakrapštyti Rufus ir teikti pataisas.</p>
 		<a name="donate"></a>

--- a/lv/index.html
+++ b/lv/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Pirmkods</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Jūs varat veidot <a target="_blank" href="http://git-scm.com">git</a> repozitorijas klonu izmantojot:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Jūs varat veidot <a target="_blank" href="http://git-scm.com">git</a> repozitorijas klonu izmantojot:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Papildinformācijai skatieties <a target="_blank" href="https://github.com/pbatard/rufus">github project</a>.</li></ul>
 			Ja esat izstrādātājs, jūs varat palīdzēt projektam atsūtot savus <b>Rufus</b> labojumus, papildinājumus, u.c.</p>
 		<a name="donate"></a>

--- a/mi/index.html
+++ b/mi/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Waehere pūtake</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MP)</span></li>
-			<li>Otiia, ka taea e koe te tārua i te kaipupuri <a target="_blank" href="http://git-scm.com">git</a> mā te whakamahi:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Otiia, ka taea e koe te tārua i te kaipupuri <a target="_blank" href="http://git-scm.com">git</a> mā te whakamahi:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Mō ētahi atu mōhiohio, tirohia <a target="_blank" href="https://github.com/pbatard/rufus">te kaupapa github</a>.</li></ul>
 			Mēnā he kaiwhakawhanake koe, he tino whakahauhautia koe ki te tākaro i a Rufus me te tāpae kōrero.</p>
 		<a name="donate"></a>

--- a/mk/index.html
+++ b/mk/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Изворен код</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Алтернативно, можете да го клонирате <a target="_blank" href="http://git-scm.com">git</a> репоситори користејќи:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Алтернативно, можете да го клонирате <a target="_blank" href="http://git-scm.com">git</a> репоситори користејќи:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>За повеќе информации, видете го <a target="_blank" href="https://github.com/pbatard/rufus">проектот github</a>.</li></ul>
 			Ако сте програмер, силно Ве охрабруваме да го менувате Rufus и да ни ги испраќате подобрувањата.</p>
 		<a name="donate"></a>

--- a/ms/index.html
+++ b/ms/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Kod Sumber</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Secara alternatif, anda boleh mengklon repositori <a target="_blank" href="http://git-scm.com">git</a> menggunakan:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Secara alternatif, anda boleh mengklon repositori <a target="_blank" href="http://git-scm.com">git</a> menggunakan:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Untuk maklumat lanjut, lihat <a target="_blank" href="https://github.com/pbatard/rufus">projek github</a>.</li></ul>
 			Jika anda adalah pembangun, anda sangat digalakkan untuk bekerjasama dengan Rufus dan menghantar penampal (patch).</p>
 		<a name="donate"></a>

--- a/nb/index.html
+++ b/nb/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Kildekode</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Alternativt kan du klone <a target="_blank" href="http://git-scm.com">git</a>-arkivet med:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Alternativt kan du klone <a target="_blank" href="http://git-scm.com">git</a>-arkivet med:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>For mer informasjon, vennligst se <a target="_blank" href="https://github.com/pbatard/rufus">github-prosjektet</a>.</li></ul>
 			Er du programvareutvikler, er du oppfordret til å forbedre Rufus og sende inn programendringer.</p>
 		<a name="donate"></a>

--- a/nl/index.html
+++ b/nl/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Broncode</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Als alternatief kunt u de <a target="_blank" href="http://git-scm.com">git</a>-repository op de volgende manier klonen:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Als alternatief kunt u de <a target="_blank" href="http://git-scm.com">git</a>-repository op de volgende manier klonen:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Zie het <a target="_blank" href="https://github.com/pbatard/rufus">github-project</a> voor meer informatie.</li></ul>
 			Als ontwikkelaar wordt u sterk aangemoedigd om aan Rufus te knutselen en patches in te dienen.</p>
 		<a name="donate"></a>

--- a/or/index.html
+++ b/or/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>ମୂଳ କୋଡ୍</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 ଏମବି)</span></li>
-			<li>ଆପଣ ଏହାର ସମ୍ପୂର୍ଣ ଅବିକଳ <a target="_blank" href="http://git-scm.com">git</a> ମାଧ୍ୟମରେ ବି କରିପାରିବେ:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>ଆପଣ ଏହାର ସମ୍ପୂର୍ଣ ଅବିକଳ <a target="_blank" href="http://git-scm.com">git</a> ମାଧ୍ୟମରେ ବି କରିପାରିବେ:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>ଅଧିକ ଜାଣିବା ପାଇଁ <a target="_blank" href="https://github.com/pbatard/rufus">ଗିଟହବ ପ୍ରଜେକ୍ଟ</a> ଦେଖନ୍ତୁ.</li></ul>
 			ଯଦି ଆପଣ ଜଣେ ଡେଭେଲପର, ଆପଣ ସର୍ବଦା ଋଫସ ସହ ସମୟ ବିତାଇ ପାରିବେ ଓ ପାଚ ବି ପଠାଇ ପାରିବେ.</p>
 		<a name="donate"></a>

--- a/pl/index.html
+++ b/pl/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Kod źródłowy</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Możesz również sklonować repozytorium <a target="_blank" href="http://git-scm.com">git</a> używając:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Możesz również sklonować repozytorium <a target="_blank" href="http://git-scm.com">git</a> używając:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Aby dowiedzieć się więcej, zobacz <a target="_blank" href="https://github.com/pbatard/rufus">projekt na GitHub</a>.</li></ul>
 			Jeśli jesteś programistą, bardzo zachęcam do majsterkowania przy Rufusie i zgłaszania poprawek.</p>
 		<a name="donate"></a>

--- a/pt/index.html
+++ b/pt/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Código Fonte</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Em alternativa, pode clonar o repositório <a target="_blank" href="http://git-scm.com">git</a>:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Em alternativa, pode clonar o repositório <a target="_blank" href="http://git-scm.com">git</a>:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Para mais informações, visite o <a target="_blank" href="https://github.com/pbatard/rufus">projeto no github</a>.</li></ul>
 			Se é programador, sinta-se com coragem para contribuir para o Rufus e a enviar-nos as suas alterações ou atualizações.</p>
 		<a name="donate"></a>

--- a/pt_BR/index.html
+++ b/pt_BR/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Código-fonte</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Alternativamente você pode clonar o <a target="_blank" href="http://git-scm.com">git</a> repositório usando:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Alternativamente você pode clonar o <a target="_blank" href="http://git-scm.com">git</a> repositório usando:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Para mais informações veja: <a target="_blank" href="https://github.com/pbatard/rufus">github project</a>.</li></ul>
 			Se você é desenvolvedor sinta-se encorajado a contribuir com Rufus e enviar patches.</p>
 		<a name="donate"></a>

--- a/ro/index.html
+++ b/ro/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Codul Sursă</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Alternativ, puteți clona depozitul <a target="_blank" href="http://git-scm.com">git</a> folosind:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Alternativ, puteți clona depozitul <a target="_blank" href="http://git-scm.com">git</a> folosind:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Pentru mai multe informații, consultați <a target="_blank" href="https://github.com/pbatard/rufus">proiectul github</a>.</li></ul>
 			Dacă sunteți un dezvoltator, vă încurajăm să utilizaţi aplicaţia Rufus și să-i aduceţi îmbunătăţiri.</p>
 		<a name="donate"></a>

--- a/ro_RO.html
+++ b/ro_RO.html
@@ -355,7 +355,7 @@
 
 		<h2>Codul Sursă</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.13.zip">Rufus 3.13</a> <span dir="ltr">(3.5 MB)</span></li>
-			<li>Alternativ, puteți clona depozitul <a target="_blank" href="http://git-scm.com">git</a> folosind:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Alternativ, puteți clona depozitul <a target="_blank" href="http://git-scm.com">git</a> folosind:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Pentru mai multe informații, consultați <a target="_blank" href="https://github.com/pbatard/rufus">proiectul github</a>.</li></ul>
 			Dacă sunteți un dezvoltator, vă încurajăm să utilizaţi aplicaţia Rufus și să-i aduceţi îmbunătăţiri.</p>
 		<a name="donate"></a>

--- a/ru/index.html
+++ b/ru/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Исходный код</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 МБ)</span></li>
-			<li>Кроме того, вы можете клонировать <a target="_blank" href="http://git-scm.com">git</a> репозиторий с помощью:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Кроме того, вы можете клонировать <a target="_blank" href="http://git-scm.com">git</a> репозиторий с помощью:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Дополнительные сведения см. в разделе <a target="_blank" href="https://github.com/pbatard/rufus">проект github</a>.</li></ul>
 			Если вы разработчик, вы можете сильно помочь в развитии Rufus, прислав свои патчи с изменениями.</p>
 		<a name="donate"></a>

--- a/si/index.html
+++ b/si/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>ප්රභව කේතය</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>විකල්පයක් ලෙස, ඔබට මෙය භාවිතා කරමින් <a target="_blank" href="http://git-scm.com"> git </a> නිධිය ක්ලෝන කළ හැකිය:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>විකල්පයක් ලෙස, ඔබට මෙය භාවිතා කරමින් <a target="_blank" href="http://git-scm.com"> git </a> නිධිය ක්ලෝන කළ හැකිය:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>වැඩි විස්තර සඳහා, බලන්න <a target="_blank" href="https://github.com/pbatard/rufus">github ව්‍යාපෘතිය</a>.</li></ul>
 			ඔබ සංවර්ධකයෙකු නම්, රූෆස් සමඟ සම්බන්ධ වී පැච් ඉදිරිපත් කිරීමට ඔබව දිරිමත් කරනු ලැබේ.</p>
 		<a name="donate"></a>

--- a/sk/index.html
+++ b/sk/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Zdrojový kód</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Alebo si môžete skopírovať <a target="_blank" href="http://git-scm.com">git</a> repozitár:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Alebo si môžete skopírovať <a target="_blank" href="http://git-scm.com">git</a> repozitár:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Pre viac informácií si pozrite  <a target="_blank" href="https://github.com/pbatard/rufus">github projekt</a>.</li></ul>
 			Ak ste vývojár, môžete do programu zasahovať a vytvárať patche.</p>
 		<a name="donate"></a>

--- a/sl/index.html
+++ b/sl/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Izvorna koda</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Lahko pa tudi klonirate repozitorij <a target="_blank" href="http://git-scm.com">Git</a> z:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Lahko pa tudi klonirate repozitorij <a target="_blank" href="http://git-scm.com">Git</a> z:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Za več informacij glejte <a target="_blank" href="https://github.com/pbatard/rufus">projekt na GitHubu</a>.</li></ul>
 			Če ste razvijalec, so vaši popravki dobrodošli.</p>
 		<a name="donate"></a>

--- a/sq/index.html
+++ b/sq/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Kodi i Burimit</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Përndryshe, ju mund të klononi depozitën <ahref="http://git-scm.com">git</a> duke përdorur:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Përndryshe, ju mund të klononi depozitën <ahref="http://git-scm.com">git</a> duke përdorur:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Per me shume informacion, shikoni <a target="_blank" href="https://github.com/pbatard/rufus">github project</a>.</li></ul>
 			Nëse jeni një programues, ju jeni shumë të inkurajuar që të kopjoni me Rufusin dhe të dorëzoni arna.</p>
 		<a name="donate"></a>

--- a/sr/index.html
+++ b/sr/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Izvor koda</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Altenativno, možete klonirati <a target="_blank" href="http://git-scm.com">git</a>  repozitorijum  pomoću:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Altenativno, možete klonirati <a target="_blank" href="http://git-scm.com">git</a>  repozitorijum  pomoću:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Za još informacija, pogledajte naš <a target="_blank" href="https://github.com/pbatard/rufus">github projekat</a>.</li></ul>
 			Ako ste programer, veoma ste ohrabreni da pravite zakrpe za Rufus.</p>
 		<a name="donate"></a>

--- a/sv/index.html
+++ b/sv/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Källkod</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Som alternativ kan du klona <a target="_blank" href="http://git-scm.com">git</a>-förrådet med:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Som alternativ kan du klona <a target="_blank" href="http://git-scm.com">git</a>-förrådet med:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>För mer information, se <a target="_blank" href="https://github.com/pbatard/rufus">github projekt</a>.</li></ul>
 			Är du en utvecklare är du välkommen att göra egna ändringar i Rufus och skicka in dina "patchar".</p>
 		<a name="donate"></a>

--- a/th/index.html
+++ b/th/index.html
@@ -422,7 +422,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>ซอร์สโค๊ด (คำสั่งในการเขียนโปรแกรม)</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>นอกจากนี้แล้ว คุณสามารถโคลน <a target="_blank" href="http://git-scm.com">Git repository</a> โดยใช้:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>นอกจากนี้แล้ว คุณสามารถโคลน <a target="_blank" href="http://git-scm.com">Git repository</a> โดยใช้:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>หากต้องการข้อมูลเพิ่มเติม โปรดดู <a target="_blank" href="https://github.com/pbatard/rufus">github project</a>.</li></ul>
 			หากคุณเป็นนักพัฒนา คุณสามารถทดสอบและส่งแพทช์ของRufusได้</p>
 		<a name="donate"></a>

--- a/tr/index.html
+++ b/tr/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Kaynak Kodu</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Alternatif olarak, <a target="_blank" href="http://git-scm.com">git</a> deposunu kullanarak klonlayabilirsiniz:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Alternatif olarak, <a target="_blank" href="http://git-scm.com">git</a> deposunu kullanarak klonlayabilirsiniz:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Daha fazla bilgi için <a target="_blank" href="https://github.com/pbatard/rufus">github projesine</a> bakın.</li></ul>
 			Geliştiriciyseniz, Rufus'u düzeltmelere ve yama sunmaya teşvik ediyoruz.</p>
 		<a name="donate"></a>

--- a/uk/index.html
+++ b/uk/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Вихідний код</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 Мб)</span></li>
-			<li>Крім того, ви можете клонувати <a target="_blank" href="http://git-scm.com">git</a> репозиторій за допомогою:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Крім того, ви можете клонувати <a target="_blank" href="http://git-scm.com">git</a> репозиторій за допомогою:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Додаткові відомості дивіться у розділі <a target="_blank" href="https://github.com/pbatard/rufus">проекту github</a>.</li></ul>
 			Якщо ви є розробником, ви можете сильно допомогти у розвитку Rufus, надіславши свої патчі зі змінами.</p>
 		<a name="donate"></a>

--- a/ur/index.html
+++ b/ur/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>اس کی کوڈنگ</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip"><span dir="ltr">3.18 Rufus</span></a> <span dir="rtl">(4.5 MB)</span></li>
-			<li>متبادل طور پر، آپ <a target="_blank" href="http://git-scm.com">git</a> کے انبار کو کلون کرسکتے ہیں، درجِ ذیل کوڈ کو استعمال کرتے ہوئے:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>متبادل طور پر، آپ <a target="_blank" href="http://git-scm.com">git</a> کے انبار کو کلون کرسکتے ہیں، درجِ ذیل کوڈ کو استعمال کرتے ہوئے:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>مزید معلومات کے لئے، <a target="_blank" href="https://github.com/pbatard/rufus">github project</a> ملاحظہ کریں۔</li></ul>
 			اگر آپ ایک ڈویلپر ہیں تو آپ کی حوصلہ افزائی کی جاتی ہے کہ آپ روفُس کے ساتھ چھیڑ چھاڑ کریں اور اس کے پیچز جمع کروائیں۔</p>
 		<a name="donate"></a>

--- a/vi/index.html
+++ b/vi/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>Mã nguồn</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>Theo cách khác, bạn có thể sao chép kho <a target="_blank" href="http://git-scm.com">git</a> bằng lệnh:			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>Theo cách khác, bạn có thể sao chép kho <a target="_blank" href="http://git-scm.com">git</a> bằng lệnh:			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>Để có thêm thông tin, hãy xem <a target="_blank" href="https://github.com/pbatard/rufus">dự án github</a>.</li></ul>
 			Nếu bạn là một nhà phát triển, bạn được khuyến kích giúp đỡ tìm và gửi các bản khắc phục cho Rufus.</p>
 		<a name="donate"></a>

--- a/yue/index.html
+++ b/yue/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>程式原始碼</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>除此之外，亦都畀打指令 <a target="_blank" href="http://git-scm.com">Clone Git</a>：			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>除此之外，亦都畀打指令 <a target="_blank" href="http://git-scm.com">Clone Git</a>：			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>或者睇睇 <a target="_blank" href="https://github.com/pbatard/rufus">GitHub 專案</a>。</li></ul>
 			歡迎各路 Programmers 過嚟幫拖，令 Rufus 做得更加好。</p>
 		<a name="donate"></a>

--- a/zh/index.html
+++ b/zh/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>源代码</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>当然，你也可以使用如下方式克隆 <a target="_blank" href="http://git-scm.com">git</a> 源代码库：			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>当然，你也可以使用如下方式克隆 <a target="_blank" href="http://git-scm.com">git</a> 源代码库：			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>更多详情请查看 <a target="_blank" href="https://github.com/pbatard/rufus">github 项目主页</a> 。</li></ul>
 			非常欢迎开发者来折腾 Rufus 和提交补丁。</p>
 		<a name="donate"></a>

--- a/zh_TW/index.html
+++ b/zh_TW/index.html
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 
 		<h2>原始碼</h2>
 			<p><ul><li><a target="_blank" href="https://github.com/pbatard/rufus/archive/v3.18.zip">Rufus 3.18</a> <span dir="ltr">(4.5 MB)</span></li>
-			<li>或者，你也可以使用以下方法複製<a target="_blank" href="http://git-scm.com">git</a> 儲存庫：			<pre dir="ltr">$ git clone git://github.com/pbatard/rufus</pre></li>
+			<li>或者，你也可以使用以下方法複製<a target="_blank" href="http://git-scm.com">git</a> 儲存庫：			<pre dir="ltr">$ git clone https://github.com/pbatard/rufus</pre></li>
 			<li>詳情請參閱 <a target="_blank" href="https://github.com/pbatard/rufus">github專案</a>。</li></ul>
 			如果你是開發者，歡迎來協助 Rufus 讓它更好。</p>
 		<a name="donate"></a>


### PR DESCRIPTION
GitHub has deprecated the `git://` protocol – in fact, it may have been removed entirely by now.