### PR TITLE
Fixed swapped links in Czech translation

### DIFF
--- a/cs/index.html
+++ b/cs/index.html
@@ -488,7 +488,7 @@ document.addEventListener("DOMContentLoaded", function(event)
 	<a name="license"></a>
 	<h2>Licence</h2>
 	<p><a target="_blank" href="http://www.gnu.org/licenses/gpl.html">GNU General Public Licence (GPL) verze 3</a>, nebo novější.<br />Šiřte, upravujte i prodávejte Rufus pod záštitou GPLv3 licence.</p>
-	<p>Rufus zvládne i začátečník! Programátorská guru najdou jeho zdrojové kódy spolu s knihovnou <a target="_blank" href="https://github.com/pbatard/rufus">MinGW32</a> ve <a target="_blank" href="http://mingw-w64.org">veřejném GIT zdroji</a>.</p>
+	<p>Rufus zvládne i začátečník! Programátorská guru najdou jeho zdrojové kódy spolu s knihovnou <a target="_blank" href="http://mingw-w64.org">MinGW32</a> ve <a target="_blank" href="https://github.com/pbatard/rufus">veřejném GIT zdroji</a>.</p>
 	<a name="changelog"></a>
 	<h2>Seznam změn</h2>
 	<ul dir="ltr">


### PR DESCRIPTION
Hello,
I've noticed today that links to MinGW and Rufus' GitHub were swapped out in the Czech translation (MinGW32 text pointed to Rufus GitHub, and Rufus GitHub pointed to MinGW homepage).

Hope I've made the changes correctly and didn't overlook any other issue.
Cheers!